### PR TITLE
Use underlying (s3) reader object, so from value is respected in ReadAt

### DIFF
--- a/base/reader.go
+++ b/base/reader.go
@@ -106,7 +106,7 @@ func (r *streamReader) ReadAt(dest []byte, off int64) (n int, err error) {
 	if _, err = r.reader.Seek(off, io.SeekStart); err != nil {
 		return n, err
 	}
-	return r.Read(dest)
+	return r.reader.Read(dest)
 }
 
 func NewStreamReader(stream *option.Stream, reedSeeker io.ReadSeeker) io.ReadCloser {


### PR DESCRIPTION
Reading parquet files from afs s3 via the segmentio library was failing, as the magic footer was corrupted.  It seems the ReadAt was returning the start of the file, not the last four bytes (that should always equal "PAR1").

Following the code, i saw that base/reader.go ReadAt calls r.reader.Seek.  This sets r.reader.from.  However it then calls r.Read, which has no access to r.reader.from, and sets it's own from value (beginning of the file).  Converting r.Read into r.reader.Read fixes this in my testing, and the segmentio library now happily reads parquet files from s3 via afs.